### PR TITLE
🎉 Release 10.10.0-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,9 @@
 
 ### Misc
 
+- Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/jellyfin/pull/4)]
+- Update renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/jellyfin/pull/3)]
+- Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/jellyfin/pull/4)]
+- Update renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/jellyfin/pull/3)]
 - Configure Renovate [[#1](https://github.com/CrystalNET-org/jellyfin/pull/1)]
 - Configure Renovate [[#1](https://github.com/CrystalNET-org/jellyfin/pull/1)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Misc
 
+- Update renovate/renovate Docker tag to v38 [[#6](https://github.com/CrystalNET-org/jellyfin/pull/6)]
+- Update renovate/renovate Docker tag to v38 [[#6](https://github.com/CrystalNET-org/jellyfin/pull/6)]
 - Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/jellyfin/pull/4)]
 - Update renovate/renovate Docker tag to v37.440.7 [[#3](https://github.com/CrystalNET-org/jellyfin/pull/3)]
 - Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/jellyfin/pull/4)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [10.9.11](https://github.com/CrystalNET-org/jellyfin/releases/tag/10.9.11) - 2024-10-27
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update renovate/renovate Docker tag to v38.132.3 [[#10](https://github.com/CrystalNET-org/jellyfin/pull/10)]
+
 ## [0.0.1](https://github.com/CrystalNET-org/jellyfin/releases/tag/0.0.1) - 2024-10-21
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Misc
 
+- Migrate renovate config [[#7](https://github.com/CrystalNET-org/jellyfin/pull/7)]
+- Migrate renovate config [[#7](https://github.com/CrystalNET-org/jellyfin/pull/7)]
 - Update renovate/renovate Docker tag to v38 [[#6](https://github.com/CrystalNET-org/jellyfin/pull/6)]
 - Update renovate/renovate Docker tag to v38 [[#6](https://github.com/CrystalNET-org/jellyfin/pull/6)]
 - Update woodpeckerci/plugin-git Docker tag to v2.6.0 [[#4](https://github.com/CrystalNET-org/jellyfin/pull/4)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.0.1](https://github.com/CrystalNET-org/jellyfin/releases/tag/0.0.1) - 2024-10-21
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Configure Renovate [[#1](https://github.com/CrystalNET-org/jellyfin/pull/1)]
+- Configure Renovate [[#1](https://github.com/CrystalNET-org/jellyfin/pull/1)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `10.9.11` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [10.9.11](https://github.com/CrystalNET-org/jellyfin/releases/tag/10.9.11) - 2024-10-27

### Misc

- Update renovate/renovate Docker tag to v38.132.3 [[#10](https://github.com/CrystalNET-org/jellyfin/pull/10)]